### PR TITLE
Map stat_type for nominal and numerical stat_types

### DIFF
--- a/src/jsviz/depprob.js
+++ b/src/jsviz/depprob.js
@@ -27,6 +27,19 @@ function depprob_demo(depprob, rows, schema) {
     element.classList[state ? 'add' : 'remove'](className)
   }
 
+
+  if (schema) {
+    for (const col of schema) {
+      if (col.stat_type = 'numerical') {
+        col.stat_type = 'realAdditive';
+      }
+
+      if (col.stat_type = 'nominal') {
+        col.stat_type = 'categorical';
+      }
+    }
+  }
+
   // convert the data to an MI object for VizGPM
   var associations = {}
   // very strangely, the pandas data frame json looks like an object


### PR DESCRIPTION
cc @fsaad - by your request, schema can now have "nominal" and "numerical" and I just map it to "categorical" and "realAdditive" on the JS side.