### PR TITLE
Don't ignore tests with the string `__ci_`.

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -24,7 +24,7 @@ test:
     - pytest 2.8.*
     - python 2.7.*
   commands:
-    - python -m pytest --pyargs iventure -k "not __ci_"
+    - python -m pytest --pyargs iventure
 
 about:
   home: https://github.com/probcomp/iventure


### PR DESCRIPTION
Since there are no tests named with the string `__ci_` there is no reason to ignore them.